### PR TITLE
Filter out days from other months

### DIFF
--- a/src/views/CalendarView.vue
+++ b/src/views/CalendarView.vue
@@ -25,10 +25,8 @@
       <!-- Day Cells for a 31-day month starting on Tuesday (like March 2022) -->
       <!-- Leading empty cells for previous month -->
       <div class="day-cell empty">
-         <span class="day-number">27</span>
       </div>
       <div class="day-cell empty">
-         <span class="day-number">28</span>
       </div>
       <!-- Days 1 to 31 -->
       <div class="day-cell">


### PR DESCRIPTION
Remove day numbers from leading empty cells in the calendar view to only show days of the current month.

---
<a href="https://cursor.com/background-agent?bcId=bc-64911d68-8933-43b0-a83b-f0ec2a52da4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64911d68-8933-43b0-a83b-f0ec2a52da4b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

